### PR TITLE
Use u32 for memory offsets sizes instead of usize to avoid i32->usize casts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,7 +39,7 @@ dependencies = [
 
 [[package]]
 name = "it-lilo"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "fluence-it-types",
  "it-memory-traits",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "it-memory-traits"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "thiserror",
 ]
@@ -280,7 +280,7 @@ checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 
 [[package]]
 name = "wasmer-interface-types-fl"
-version = "0.21.1"
+version = "0.22.0"
 dependencies = [
  "fluence-it-types",
  "it-lilo",

--- a/crates/it-lilo/Cargo.toml
+++ b/crates/it-lilo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "it-lilo"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Fluence Labs"]
 description = "Defines some helper utils for lifting/lowering IT"
 edition = "2018"
@@ -12,7 +12,7 @@ path = "src/lib.rs"
 
 [dependencies]
 fluence-it-types = { path = "../it-types/", version = "0.3.0" }
-it-memory-traits = { path = "../it-memory-traits", version = "0.1.0" }
+it-memory-traits = { path = "../it-memory-traits", version = "0.2.0" }
 
 paste = "1.0.5"
 thiserror = "1.0.24"

--- a/crates/it-lilo/src/lifter/lift_record.rs
+++ b/crates/it-lilo/src/lifter/lift_record.rs
@@ -30,7 +30,7 @@ use it_memory_traits::{SequentialMemoryView, SequentialReader};
 pub fn record_lift_memory<R: RecordResolvable, MV: for<'a> SequentialMemoryView<'a>>(
     lifter: &ILifter<'_, R, MV>,
     record_type: &IRecordType,
-    offset: usize,
+    offset: u32,
 ) -> LiResult<IValue> {
     let mut values = Vec::with_capacity(record_type.fields.len());
 
@@ -75,7 +75,7 @@ fn read_string<MV: for<'a> SequentialMemoryView<'a>>(
     let offset = seq_reader.read_u32();
     let size = seq_reader.read_u32();
 
-    let string_mem = reader.read_raw_u8_array(offset as _, size as _)?;
+    let string_mem = reader.read_raw_u8_array(offset, size)?;
 
     let string = String::from_utf8(string_mem)?;
     Ok(string)
@@ -88,7 +88,7 @@ fn read_byte_array<MV: for<'a> SequentialMemoryView<'a>>(
     let offset = seq_reader.read_u32();
     let size = seq_reader.read_u32();
 
-    let array = reader.read_raw_u8_array(offset as _, size as _)?;
+    let array = reader.read_raw_u8_array(offset, size)?;
 
     Ok(IValue::ByteArray(array))
 }
@@ -101,7 +101,7 @@ fn read_array<R: RecordResolvable, MV: for<'a> SequentialMemoryView<'a>>(
     let offset = seq_reader.read_u32();
     let size = seq_reader.read_u32();
 
-    super::array_lift_memory(lifter, value_type, offset as _, size as _)
+    super::array_lift_memory(lifter, value_type, offset, size)
 }
 
 fn read_record<R: RecordResolvable, MV: for<'a> SequentialMemoryView<'a>>(
@@ -113,5 +113,5 @@ fn read_record<R: RecordResolvable, MV: for<'a> SequentialMemoryView<'a>>(
 
     let record_type = lifter.resolver.resolve_record(record_type_id)?;
 
-    record_lift_memory(lifter, &record_type, offset as _)
+    record_lift_memory(lifter, &record_type, offset)
 }

--- a/crates/it-lilo/src/lifter/macros.rs
+++ b/crates/it-lilo/src/lifter/macros.rs
@@ -122,12 +122,12 @@ macro_rules! read_array_ty {
     ($func_name:ident, $ty:ident, $ity:ident) => {
         pub fn $func_name(
             &self,
-            offset: usize,
-            elements_count: usize,
+            offset: u32,
+            elements_count: u32,
         ) -> super::LiResult<Vec<crate::IValue>> {
-            let reader =
-                self.sequential_reader(offset, std::mem::size_of::<$ty>() * elements_count)?;
-            let mut result = Vec::with_capacity(elements_count);
+            let reader = self
+                .sequential_reader(offset, (std::mem::size_of::<$ty>() as u32) * elements_count)?;
+            let mut result = Vec::with_capacity(elements_count as usize);
 
             for _ in 0..elements_count {
                 let value = paste::paste! { reader.[<read_ $ty>]()};

--- a/crates/it-lilo/src/lifter/memory_reader.rs
+++ b/crates/it-lilo/src/lifter/memory_reader.rs
@@ -34,16 +34,16 @@ impl<MV: for<'a> SequentialMemoryView<'a>> MemoryReader<MV> {
     /// checks assuming that reader is well-formed.
     pub fn sequential_reader(
         &self,
-        offset: usize,
-        size: usize,
+        offset: u32,
+        size: u32,
     ) -> LiResult<<MV as SequentialMemoryView<'_>>::SR> {
         let seq_reader = self.view.sequential_reader(offset, size)?;
         Ok(seq_reader)
     }
 
-    pub fn read_raw_u8_array(&self, offset: usize, elements_count: usize) -> LiResult<Vec<u8>> {
+    pub fn read_raw_u8_array(&self, offset: u32, elements_count: u32) -> LiResult<Vec<u8>> {
         let reader = self.sequential_reader(offset, elements_count)?;
-        let mut result = Vec::with_capacity(elements_count);
+        let mut result = Vec::with_capacity(elements_count as usize);
 
         for _ in 0..elements_count {
             let value = reader.read_u8();
@@ -53,9 +53,9 @@ impl<MV: for<'a> SequentialMemoryView<'a>> MemoryReader<MV> {
         Ok(result)
     }
 
-    pub fn read_bool_array(&self, offset: usize, elements_count: usize) -> LiResult<Vec<IValue>> {
+    pub fn read_bool_array(&self, offset: u32, elements_count: u32) -> LiResult<Vec<IValue>> {
         let reader = self.sequential_reader(offset, elements_count)?;
-        let mut result = Vec::with_capacity(elements_count);
+        let mut result = Vec::with_capacity(elements_count as usize);
 
         for _ in 0..elements_count {
             let value = reader.read_u8();

--- a/crates/it-lilo/src/lowerer/lower_array.rs
+++ b/crates/it-lilo/src/lowerer/lower_array.rs
@@ -24,12 +24,12 @@ use crate::IValue;
 use it_memory_traits::{SequentialMemoryView, SequentialWriter};
 
 pub struct LoweredArray {
-    pub offset: usize,
-    pub size: usize,
+    pub offset: u32,
+    pub size: u32,
 }
 
 impl LoweredArray {
-    pub fn new(offset: usize, size: usize) -> Self {
+    pub fn new(offset: u32, size: u32) -> Self {
         Self { offset, size }
     }
 
@@ -93,6 +93,6 @@ pub fn array_lower_memory<A: Allocatable, MV: for<'a> SequentialMemoryView<'a>>(
     }
 
     let offset = seq_writer.start_offset();
-    let lowered_array = LoweredArray::new(offset as _, elements_count as _);
+    let lowered_array = LoweredArray::new(offset, elements_count);
     Ok(lowered_array)
 }

--- a/crates/it-lilo/src/lowerer/memory_writer.rs
+++ b/crates/it-lilo/src/lowerer/memory_writer.rs
@@ -31,9 +31,9 @@ impl<'i, A: Allocatable, MV: for<'a> SequentialMemoryView<'a>> MemoryWriter<'i, 
         Ok(writer)
     }
 
-    pub fn write_bytes(&self, bytes: &[u8]) -> LoResult<usize> {
+    pub fn write_bytes(&self, bytes: &[u8]) -> LoResult<u32> {
         let byte_type_tag = type_tag_form_itype(&crate::IType::U8);
-        let seq_writer = self.sequential_writer(bytes.len() as _, byte_type_tag)?;
+        let seq_writer = self.sequential_writer(bytes.len() as u32, byte_type_tag)?;
         seq_writer.write_bytes(bytes);
 
         Ok(seq_writer.start_offset())
@@ -45,7 +45,7 @@ impl<'i, A: Allocatable, MV: for<'a> SequentialMemoryView<'a>> MemoryWriter<'i, 
         type_tag: u32,
     ) -> LoResult<<MV as SequentialMemoryView<'_>>::SW> {
         let offset = self.heap_manager.allocate(size, type_tag)?;
-        let seq_writer = self.view.sequential_writer(offset, size as usize)?;
+        let seq_writer = self.view.sequential_writer(offset, size)?;
         Ok(seq_writer)
     }
 }

--- a/crates/it-lilo/src/traits/allocatable.rs
+++ b/crates/it-lilo/src/traits/allocatable.rs
@@ -19,7 +19,7 @@ use thiserror::Error as ThisError;
 pub const DEFAULT_MEMORY_INDEX: usize = 0;
 
 pub trait Allocatable {
-    fn allocate(&self, size: u32, type_tag: u32) -> Result<usize, AllocatableError>;
+    fn allocate(&self, size: u32, type_tag: u32) -> Result<u32, AllocatableError>;
 }
 
 #[derive(Debug, ThisError)]

--- a/crates/it-lilo/src/utils.rs
+++ b/crates/it-lilo/src/utils.rs
@@ -19,8 +19,8 @@ use crate::IType;
 use crate::IValue;
 
 /// Size of a value in a serialized view.
-pub fn ser_type_size(ty: &IType) -> usize {
-    const WASM_POINTER_SIZE: usize = 4;
+pub fn ser_type_size(ty: &IType) -> u32 {
+    const WASM_POINTER_SIZE: u32 = 4;
 
     match ty {
         IType::Boolean | IType::S8 | IType::U8 => 1,
@@ -46,7 +46,7 @@ pub fn ser_value_size(value: &IValue) -> u32 {
 }
 
 /// Returns the record size in bytes.
-pub fn record_size(record_type: &IRecordType) -> usize {
+pub fn record_size(record_type: &IRecordType) -> u32 {
     record_type
         .fields
         .iter()

--- a/crates/it-memory-traits/Cargo.toml
+++ b/crates/it-memory-traits/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "it-memory-traits"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Fluence Labs"]
 description = "Defines traits that IT uses for accessing memory"
 edition = "2018"

--- a/crates/it-memory-traits/src/errors.rs
+++ b/crates/it-memory-traits/src/errors.rs
@@ -20,8 +20,8 @@ use thiserror::Error as ThisError;
 pub enum MemoryAccessError {
     #[error("Out-of-bound Wasm memory access: offset {offset}, size {size}, while memory_size {memory_size}")]
     OutOfBounds {
-        offset: usize,
-        size: usize,
-        memory_size: usize,
+        offset: u32,
+        size: u32,
+        memory_size: u32,
     },
 }

--- a/crates/it-memory-traits/src/lib.rs
+++ b/crates/it-memory-traits/src/lib.rs
@@ -48,7 +48,7 @@ pub trait SequentialReader {
 }
 
 pub trait SequentialWriter {
-    fn start_offset(&self) -> usize;
+    fn start_offset(&self) -> u32;
 
     // specialization of write_array for u8
     fn write_u8(&self, value: u8);
@@ -65,17 +65,9 @@ pub trait SequentialMemoryView<'s> {
     type SR: SequentialReader + 's;
     type SW: SequentialWriter + 's;
 
-    fn sequential_writer(
-        &'s self,
-        offset: usize,
-        size: usize,
-    ) -> Result<Self::SW, MemoryAccessError>;
+    fn sequential_writer(&'s self, offset: u32, size: u32) -> Result<Self::SW, MemoryAccessError>;
 
-    fn sequential_reader(
-        &'s self,
-        offset: usize,
-        size: usize,
-    ) -> Result<Self::SR, MemoryAccessError>;
+    fn sequential_reader(&'s self, offset: u32, size: u32) -> Result<Self::SR, MemoryAccessError>;
 }
 
 pub trait Memory<View>

--- a/wasmer-it/Cargo.toml
+++ b/wasmer-it/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmer-interface-types-fl"
-version = "0.21.1"
+version = "0.22.0"
 description = "WebAssembly Interface Types library for Wasmer"
 license = "MIT"
 authors = ["The Wasmer Engineering Team <engineering@wasmer.io>"]
@@ -10,8 +10,8 @@ edition = "2018"
 [dependencies]
 fluence-it-types = { path = "../crates/it-types", version = "0.3.1", features = ["impls"] }
 it-to-bytes = { path = "../crates/to-bytes", version = "0.1.0" }
-it-lilo = { path = "../crates/it-lilo", version = "0.2.0" }
-it-memory-traits = { path = "../crates/it-memory-traits", version = "0.1.0" }
+it-lilo = { path = "../crates/it-lilo", version = "0.3.0" }
+it-memory-traits = { path = "../crates/it-memory-traits", version = "0.2.0" }
 
 nom = "5.1"
 wast = "8.0"

--- a/wasmer-it/src/errors.rs
+++ b/wasmer-it/src/errors.rs
@@ -189,10 +189,10 @@ pub enum InstructionErrorKind {
     #[error("read out of the memory bounds (index {index} > memory length {length})")]
     MemoryOutOfBoundsAccess {
         /// The access index.
-        index: usize,
+        index: u32,
 
         /// The memory length.
-        length: usize,
+        length: u32,
     },
 
     /// The string contains invalid UTF-8 encoding.

--- a/wasmer-it/src/interpreter/instructions/arrays.rs
+++ b/wasmer-it/src/interpreter/instructions/arrays.rs
@@ -47,12 +47,12 @@ where
                 )
             })?;
 
-            let offset: usize = to_native::<i32>(inputs.remove(0), instruction.clone())?
+            let offset: u32 = to_native::<i32>(inputs.remove(0), instruction.clone())?
                 .try_into()
                 .map_err(|e| (e, "offset").into())
                 .map_err(|k| InstructionError::from_error_kind(instruction.clone(), k))?;
 
-            let size: usize = to_native::<i32>(inputs.remove(0), instruction.clone())?
+            let size: u32 = to_native::<i32>(inputs.remove(0), instruction.clone())?
                 .try_into()
                 .map_err(|e| (e, "size").into())
                 .map_err(|k| InstructionError::from_error_kind(instruction.clone(), k))?;
@@ -79,9 +79,8 @@ where
 
             let li_helper = lilo::LiHelper::new(&**instance);
             let lifter = ILifter::new(memory_view, &li_helper);
-            let array =
-                it_lilo::lifter::array_lift_memory(&lifter, &value_type, offset as _, size as _)
-                    .map_err(|e| InstructionError::from_li(instruction.clone(), e))?;
+            let array = it_lilo::lifter::array_lift_memory(&lifter, &value_type, offset, size)
+                .map_err(|e| InstructionError::from_li(instruction.clone(), e))?;
 
             log::trace!("array.lift_memory: pushing {:?} on the stack", array);
             runtime.stack.push(array);

--- a/wasmer-it/src/interpreter/instructions/byte_arrays.rs
+++ b/wasmer-it/src/interpreter/instructions/byte_arrays.rs
@@ -33,11 +33,11 @@ executable_instruction!(
                     )
                 })?;
 
-            let pointer: usize = to_native::<i32>(inputs.remove(0), instruction.clone())?
+            let pointer: u32 = to_native::<i32>(inputs.remove(0), instruction.clone())?
                 .try_into()
                 .map_err(|e| (e, "pointer").into())
                 .map_err(|k| InstructionError::from_error_kind(instruction.clone(), k))?;
-            let length: usize = to_native::<i32>(inputs.remove(0), instruction.clone())?
+            let length: u32 = to_native::<i32>(inputs.remove(0), instruction.clone())?
                 .try_into()
                 .map_err(|e| (e, "length").into())
                 .map_err(|k| InstructionError::from_error_kind(instruction.clone(), k))?;
@@ -74,12 +74,12 @@ executable_instruction!(
                 )
             })?;
 
-            let array_pointer: usize = to_native::<i32>(inputs.remove(0), instruction.clone())?
+            let array_pointer: u32 = to_native::<i32>(inputs.remove(0), instruction.clone())?
                 .try_into()
                 .map_err(|e| (e, "pointer").into())
                 .map_err(|k| InstructionError::from_error_kind(instruction.clone(), k))?;
             let array: Vec<u8> = to_native(inputs.remove(0), instruction.clone())?;
-            let length: i32 = array.len().try_into().map_err(|_| {
+            let length: u32 = array.len().try_into().map_err(|_| {
                 InstructionError::from_error_kind(
                     instruction.clone(),
                     InstructionErrorKind::NegativeValue { subject: "array_length" },
@@ -99,14 +99,14 @@ executable_instruction!(
                 .view();
 
             let writer = memory_view
-                .sequential_writer(array_pointer, array.len())
+                .sequential_writer(array_pointer, array.len() as u32)
                 .map_err(|e| InstructionError::from_memory_access(instruction.clone(), e))?;
 
             writer.write_bytes(&array);
 
             log::debug!("string.lower_memory: pushing {}, {} on the stack", array_pointer, length);
             runtime.stack.push(IValue::I32(array_pointer as i32));
-            runtime.stack.push(IValue::I32(length));
+            runtime.stack.push(IValue::I32(length as i32));
 
             Ok(())
         }

--- a/wasmer-it/src/interpreter/instructions/lilo/lo_helper.rs
+++ b/wasmer-it/src/interpreter/instructions/lilo/lo_helper.rs
@@ -51,7 +51,7 @@ where
     SequentialMemoryView: (for<'a> wasm::structures::SequentialMemoryView<'a>),
     Instance: wasm::structures::Instance<Export, LocalImport, Memory, SequentialMemoryView>,
 {
-    fn allocate(&self, size: u32, type_tag: u32) -> Result<usize, AllocatableError> {
+    fn allocate(&self, size: u32, type_tag: u32) -> Result<u32, AllocatableError> {
         use AllocatableError::*;
 
         use crate::interpreter::instructions::ALLOCATE_FUNC_INDEX;

--- a/wasmer-it/src/interpreter/instructions/records.rs
+++ b/wasmer-it/src/interpreter/instructions/records.rs
@@ -44,7 +44,7 @@ where
                 )
             })?;
 
-            let offset: usize = to_native::<i32>(inputs.remove(0), instruction.clone())?
+            let offset: u32 = to_native::<i32>(inputs.remove(0), instruction.clone())?
                 .try_into()
                 .map_err(|e| (e, "offset").into())
                 .map_err(|k| InstructionError::from_error_kind(instruction.clone(), k))?;
@@ -146,7 +146,7 @@ where
                             .map_err(|e| InstructionError::from_lo(instruction.clone(), e))?;
 
                     log::debug!("record.lower_memory: pushing {} on the stack", offset);
-                    runtime.stack.push(IValue::I32(offset));
+                    runtime.stack.push(IValue::I32(offset as i32));
 
                     Ok(())
                 }

--- a/wasmer-it/src/interpreter/instructions/strings.rs
+++ b/wasmer-it/src/interpreter/instructions/strings.rs
@@ -33,11 +33,11 @@ executable_instruction!(
                     )
                 })?;
 
-            let pointer: usize = to_native::<i32>(inputs.remove(0), instruction.clone())?
+            let pointer: u32 = to_native::<i32>(inputs.remove(0), instruction.clone())?
                 .try_into()
                 .map_err(|e| (e, "pointer").into())
                 .map_err(|k| InstructionError::from_error_kind(instruction.clone(), k))?;
-            let length: usize = to_native::<i32>(inputs.remove(0), instruction.clone())?
+            let length: u32 = to_native::<i32>(inputs.remove(0), instruction.clone())?
                 .try_into()
                 .map_err(|e| (e, "length").into())
                 .map_err(|k| InstructionError::from_error_kind(instruction.clone(), k))?;
@@ -75,13 +75,13 @@ executable_instruction!(
                 )
             })?;
 
-            let string_pointer: usize = to_native::<i32>(inputs.remove(0), instruction.clone())?
+            let string_pointer: u32 = to_native::<i32>(inputs.remove(0), instruction.clone())?
                 .try_into()
                 .map_err(|e| (e, "pointer").into())
                 .map_err(|k| InstructionError::from_error_kind(instruction.clone(), k))?;
             let string: String = to_native(inputs.remove(0), instruction.clone())?;
             let string_bytes = string.as_bytes();
-            let string_length: i32 = string_bytes.len().try_into().map_err(|_| {
+            let string_length: u32 = string_bytes.len().try_into().map_err(|_| {
                 InstructionError::from_error_kind(
                     instruction.clone(),
                     InstructionErrorKind::NegativeValue { subject: "string_length" },
@@ -101,14 +101,14 @@ executable_instruction!(
                 .view();
 
             let seq_writer = memory_view
-                .sequential_writer(string_pointer, string_length as usize)
+                .sequential_writer(string_pointer, string_length)
                 .map_err(|e| InstructionError::from_memory_access(instruction.clone(), e))?;
 
             seq_writer.write_bytes(&string_bytes);
 
             log::debug!("string.lower_memory: pushing {}, {} on the stack", string_pointer, string_length);
             runtime.stack.push(IValue::I32(string_pointer as i32));
-            runtime.stack.push(IValue::I32(string_length));
+            runtime.stack.push(IValue::I32(string_length as i32));
 
             Ok(())
         }

--- a/wasmer-it/src/interpreter/wasm/structures.rs
+++ b/wasmer-it/src/interpreter/wasm/structures.rs
@@ -146,7 +146,7 @@ impl SequentialReader for EmptySequentialReader {
 }
 
 impl SequentialWriter for EmptySequentialWriter {
-    fn start_offset(&self) -> usize {
+    fn start_offset(&self) -> u32 {
         0
     }
 
@@ -161,7 +161,7 @@ impl<'a> SequentialMemoryView<'a> for EmptyMemoryView {
     type SR = EmptySequentialReader;
     type SW = EmptySequentialWriter;
 
-    fn sequential_writer(&self, offset: usize, size: usize) -> Result<Self::SW, MemoryAccessError> {
+    fn sequential_writer(&self, offset: u32, size: u32) -> Result<Self::SW, MemoryAccessError> {
         Err(MemoryAccessError::OutOfBounds {
             offset,
             size,
@@ -169,7 +169,7 @@ impl<'a> SequentialMemoryView<'a> for EmptyMemoryView {
         })
     }
 
-    fn sequential_reader(&self, offset: usize, size: usize) -> Result<Self::SR, MemoryAccessError> {
+    fn sequential_reader(&self, offset: u32, size: u32) -> Result<Self::SR, MemoryAccessError> {
         Err(MemoryAccessError::OutOfBounds {
             offset,
             size,


### PR DESCRIPTION
There are many places in the code where memory offset or size is represented as `i32`. As wasm memory can be up to 4gb in size, offset/sizes larger than 2gb will be negative is interpreted as i32. At the same time many interfaces in the codebase uses `uzise` type to represent memory offsets/sizes. This situation leads to direct `i32 -> usize` casts. And if `usize` is 64 bit and `i32` value is negative, after cast it will look like `0xFFFFFFFFxxxxxxxx`. It leads to out of bounds memory access, so this PR replaces `usize` with `u32` where appropriate, to fix existing errors and avoid adding such errors in future.